### PR TITLE
Add Hubzilla sandcastle.

### DIFF
--- a/hubzilla.Dockerfile
+++ b/hubzilla.Dockerfile
@@ -1,0 +1,36 @@
+FROM php:8.1-fpm-alpine
+
+COPY --chmod=766 volumes/root-ca/certs/root_ca.crt /usr/local/share/ca-certificates/root_ca.crt
+
+RUN \
+  cat /usr/local/share/ca-certificates/root_ca.crt >> /etc/ssl/certs/ca-certificates.crt && \
+  cat /usr/local/share/ca-certificates/root_ca.crt >> /etc/ssl1.1/certs/ca-certificates.crt
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Install required dependencies and php extensions
+ADD --chmod=755 \
+  https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
+  /usr/local/bin/
+RUN \
+  apk add --no-cache git bash && \
+  install-php-extensions gd pdo_pgsql zip
+
+
+USER www-data
+WORKDIR /var/www/html
+
+# Install and set up Hubzilla and default addons
+#
+# Also make sure we add the step CA cert to the indernal cert store used by
+# Hubzilla.
+RUN \
+  git clone "https://framagit.org/hubzilla/core.git" . && \
+  ./util/add_addon_repo "https://framagit.org/hubzilla/addons.git" hzaddons && \
+  mkdir -p "store/[data]/smarty3" && \
+  cat /usr/local/share/ca-certificates/root_ca.crt >> library/cacert.pem
+
+USER root
+
+# Set up periodic cron job to hancle background tasks
+COPY volumes/hubzilla/crontab /etc/periodic/15min/hubzilla.sh

--- a/hubzilla.castle.yml
+++ b/hubzilla.castle.yml
@@ -1,0 +1,104 @@
+# Service definition for running Hubzilla in the Sandcatsles environment.
+#
+# Include with docker compose like this:
+#
+#   % docker compose -f docker-compose.yml -f hubzilla.castle.yml -f ... up -d
+#
+# The first time you visit https://hubzilla.castle, you will have to set up the
+# instance. Check that all checks on the first screen passes, and fill in the
+# database credentials in the next one.
+#
+# Use the following settings for the database:
+#
+# - Database Server Name: hubzilla_db
+# - Database port: 0
+# - Database Login Name: postgres
+# - Database Login Password: hubzilla
+# - Database Name: postgres
+# - Database Type: PostgreSQL
+#
+# In the next screen, fill in an email for the site admin, and select a timezone.
+#
+# Ignore the warning that you have to set up a cron job, the dockerfile does
+# that for you.
+#
+# Next register a user that will be the admin of the instance. Use whatever
+# name you want, but the email address must be the same as you set in the
+# previous step. As the system is not able to send emails, you have to extract
+# the registration token manually, using the below command:
+#
+#   % docker compose exec hubzilla_db psql postgres postgres -c \
+#     "select reg_hash from register where reg_email='hubzilla@example.com';"
+#
+# (Use the email address of the user you registered.)
+#
+# Paste the returned `reg_hash` into the verification token field in the next
+# screen, and click "Verify".
+#
+# Hubzilla should now be up and running!
+#
+services:
+  hubzilla:
+    container_name: hubzilla.castle
+    labels:
+      - traefik.http.routers.hubzilla.rule=Host(`hubzilla.castle`)
+      - traefik.http.routers.hubzilla.tls=true
+      - traefik.http.routers.hubzilla.tls.certresolver=smallstep
+      - traefik.port=3042
+      - traefik.enable=true
+    depends_on:
+      - hubzilla_db
+      - hubzilla_fpm
+    image: nginx:stable-alpine
+    volumes:
+      - 'hubzilla:/var/www/html'
+      - './volumes/hubzilla/nginx.conf:/etc/nginx/conf.d/hubzilla.conf:ro'
+    networks:
+      - hubzilla
+      - fediverse
+      - default
+    ports:
+      - '3042:443'
+
+  hubzilla_fpm:
+    depends_on:
+      - hubzilla_db
+    build:
+      dockerfile: hubzilla.Dockerfile
+    volumes:
+      - 'hubzilla:/var/www/html'
+      - './volumes/hubzilla/fpm.conf:/usr/local/etc/php-fpm.d/www.conf:ro'
+    networks:
+      - hubzilla
+      - fediverse
+
+
+  hubzilla_db:
+    image: postgres:latest
+    networks:
+      - hubzilla
+    volumes:
+      - 'hubzilla_db_data:/var/db/postgresql'
+    environment:
+      - POSTGRES_PASSWORD=hubzilla
+
+  # Configure docker's internal DNS
+  # Traefik will provide SSL termination and proxy back to hubzilla
+  proxy:
+    networks:
+      default:
+        aliases:
+          - hubzilla.castle
+      fediverse:
+        aliases:
+          - hubzilla.castle
+
+volumes:
+  hubzilla:
+    driver: local
+  hubzilla_db_data:
+    driver: local
+
+networks:
+  hubzilla:
+    internal: true

--- a/volumes/hubzilla/crontab
+++ b/volumes/hubzilla/crontab
@@ -1,0 +1,2 @@
+# Run periodic tasks for Hubzilla
+su -s /bin/bash www-data -c "cd /var/www/html; /usr/bin/php Zotlabs/Daemon/Master.php Cron > /dev/null 2>&1"

--- a/volumes/hubzilla/fpm.conf
+++ b/volumes/hubzilla/fpm.conf
@@ -1,0 +1,15 @@
+[www]
+user = www-data
+group = www-data
+
+listen = 0.0.0.0:9000
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+
+php_value[upload_max_filesize] = 5M
+php_value[post_max_size] = 20M
+php_value[max_file_uploads] = 4

--- a/volumes/hubzilla/nginx.conf
+++ b/volumes/hubzilla/nginx.conf
@@ -1,0 +1,73 @@
+#
+# Hubzilla nginx configuration for sandcastles
+#
+# TLS is terminated by the traefik router, so we will only ever see http
+# trafic here.
+#
+
+server {
+  listen 80;
+  server_name hubzilla.castle;
+
+  index index.php;
+  charset utf-8;
+  root /var/www/html;
+
+  # allow uploads up to 20MB in size
+  client_max_body_size 20m;
+  client_body_buffer_size 128k;
+
+  include mime.types;
+
+  # rewrite to front controller as default rule
+  location / {
+    if (!-e $request_filename) {
+      rewrite ^(.*)$ /index.php?q=$1;
+    }
+  }
+
+  # make sure webfinger and other well known services aren't blocked
+  # by denying dot files and rewrite request to the front controller
+  location ^~ /.well-known/ {
+    allow all;
+    if (!-e $request_filename) {
+      rewrite ^(.*)$ /index.php?q=$1;
+    }
+  }
+
+  # block these file types
+  location ~* \.(tpl|md|tgz|log|out)$ {
+    deny all;
+  }
+
+  # pass the PHP scripts to the fpm container
+  location ~* \.php$ {
+    try_files $uri =404;
+
+    fastcgi_param HTTPS on;
+
+    # NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+
+    fastcgi_pass hubzilla_fpm:9000;
+
+    include fastcgi_params;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  }
+
+  # deny access to all dot files
+  location ~ /\. {
+    deny all;
+  }
+
+  #deny access to store
+  location ~ /store {
+        deny  all;
+  }
+
+  #deny access to util
+  location ~ /util {
+        deny  all;
+  }
+}


### PR DESCRIPTION
Add support for the Hubzilla fediverse software in the Sandcastle setup. Hopefully making it easier to do interop testing between it and other fediverse software.

## Details
- It adds three containers, a nginx reverse proxy, a php-fpm container for the actual application, and a PostgreSQL container for the database.
-  I had to give the php-fpm container access to the `fediverse` network, because the system will test for properly configured redirect and TLS certs during setup. Ideally, only the nginx reverse proxy should be accessible on the `fediverse` network, but I did not find another way to solve this.
- On first boot, the Hubzilla installation must be set up. The `hubzilla.castle.yml` contains the details. Ideally this should be automated in the future, but for now this was the easiest way to get everything set up.