### PR TITLE
Updated Letterbook health check endpoint, added Mastodon env variables

### DIFF
--- a/mastodon.castle.yml
+++ b/mastodon.castle.yml
@@ -42,8 +42,9 @@ services:
       - MASTODON_DATABASE_PASSWORD=bitnami1
       - MASTODON_ELASTICSEARCH_PASSWORD=bitnami123
       - LOCAL_DOMAIN=mastodon.castle
-      - WEB_DOMAIN=mastodon.castle
-      - ALLOWED_PRIVATE_ADDRESSES=172.0.0.0/8,192.0.0.0/8
+      - MASTODON_WEB_DOMAIN=mastodon.castle
+      - MASTODON_HTTPS_ENABLED=true
+      - ALLOWED_PRIVATE_ADDRESSES=127.0.0.1,172.0.0.0/8,192.0.0.0/8
       - RAILS_ENV=development
       # - RAILS_ENV=production
   
@@ -78,10 +79,13 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - MASTODON_MODE=sidekiq
       - MASTODON_DATABASE_PASSWORD=bitnami1
+      - MASTODON_ELASTICSEARCH_HOST=mastodon_es
       - MASTODON_ELASTICSEARCH_PASSWORD=bitnami123
       - MASTODON_REDIS_HOST=mastodon_redis
       - MASTODON_DATABASE_HOST=mastodon_db
-      - ALLOWED_PRIVATE_ADDRESSES=172.0.0.0/8,192.0.0.0/8
+      - MASTODON_WEB_DOMAIN=mastodon.castle
+      - MASTODON_HTTPS_ENABLED=true
+      - ALLOWED_PRIVATE_ADDRESSES=127.0.0.1,172.0.0.0/8,192.0.0.0/8
       - RAILS_ENV=development
 
   mastodon_db:

--- a/volumes/proxy/traefik_dynamic.toml
+++ b/volumes/proxy/traefik_dynamic.toml
@@ -22,7 +22,7 @@
 
 [http.services.dockerhost]
     [http.services.dockerhost.loadBalancer.healthCheck]
-      path = "/swagger/v1/swagger.json"
+      path = "/healthz"
       port = 5127
     [[http.services.dockerhost.loadBalancer.servers]]
       url = "http://host.docker.internal:5127"


### PR DESCRIPTION
…for consistent key identifiers and working signature verification

This is a followup on the debugging I did to get a functioning back-and-forth signature verification between Letterbook and Mastodon.

Setting `MASTODON_WEB_DOMAN` and `MASTODON_HTTPS_ENABLED` will make Mastodon's routing produce URLs that start with `https://mastodon.castle`. This is important for HTTP signature verification, as the key will be downloaded from whatever URL the header presents. Prior to this change, Mastodon's key id was sent as `http://127.0.0.1/actor#main-key` and after this change it's `https://mastodon.castle/actor#main-key`.

If you have existing Mastodon containers, you will have to recreate them for this change to take effect.

This also sets the ElasticSearch address for Sidekiq and a proper health check endpoint for Letterbook.